### PR TITLE
typescript fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 BUILD*
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *~
 BUILD*
-.idea/

--- a/src/types/geographiclib.d.ts
+++ b/src/types/geographiclib.d.ts
@@ -83,6 +83,13 @@ declare class GeodesicClass {
     azi1: number;
     s12: number;
     a12: number;
+    lat2?: number
+    lon2?: number
+    azi2?: number
+    m12?: number
+    M12?: number
+    M21?: number
+    S12?: number
   };
 
   DirectLine(
@@ -130,6 +137,12 @@ declare class GeodesicClass {
     lon2: number;
     a12: number;
     s12?: number;
+    azi1?: number
+    azi2?: number
+    m12?: number
+    M12?: number
+    M21?: number
+    S12?: number
   }
 
   InverseLine(
@@ -139,9 +152,24 @@ declare class GeodesicClass {
     lon2: number,
     caps?: number
   ): any; // TODO: define GeodesicLine object
+
+  Polygon(polyline?: boolean): any // TODO: define PolygonArea object
 }
 
 export declare const Geodesic: {
+  NONE: number
+  ARC: number
+  LATITUDE: number
+  LONGITUDE: number
+  AZIMUTH: number
+  DISTANCE: number
+  STANDARD: number
+  DISTANCE_IN: number
+  REDUCEDLENGTH: number
+  GEODESICSCALE: number
+  AREA: number
+  ALL: number
+  LONG_UNROLL: number
   Geodesic: typeof GeodesicClass,
   WGS84: GeodesicClass
 };


### PR DESCRIPTION
Some quick typescript fixups re: https://sourceforge.net/p/geographiclib/discussion/1026621/thread/88041076c1/#707f/7f10/982f/ac4d/527a/6c48/ea66/6051/8eba

Ideally, the return types of `Direct` and `Indirect` should vary based off of the flags supplied in outmask (e.g., if Geodesic.AZIMUTH is supplied in the outmask to `Indirect`, the return type should have `azi1: number` instead of `azi1?: number`). I'm not sure how to do that in typescript off the top of my head, but food for thought for future work. In any case, these edits will fix up the main pain points I've encountered.