### PR TITLE
fix shape of geographiclib-dms types to match library

### DIFF
--- a/dms/types/geographiclib-dms.d.ts
+++ b/dms/types/geographiclib-dms.d.ts
@@ -1,48 +1,36 @@
-export enum DMSHemisphereIndicator {
-  NONE = 0,
-  LATITUDE = 1,
-  LONGITUDE = 2,
-  AZIMUTH = 3
-}
+export declare const NONE: 0;
+export declare const LATITUDE: 1;
+export declare const LONGITUDE: 2;
+export declare const AZIMUTH: 3;
 
-export enum DMSTrailingComponent {
-  DEGREE = 0,
-  MINUTE = 1,
-  SECOND = 2
-}
+export declare const DEGREE: 0;
+export declare const MINUTE: 1;
+export declare const SECOND: 2;
 
-export declare const DMS: {
-  NONE: DMSHemisphereIndicator.NONE,
-  LATITUDE: DMSHemisphereIndicator.LATITUDE,
-  LONGITUDE: DMSHemisphereIndicator.LONGITUDE,
-  AZIMUTH: DMSHemisphereIndicator.AZIMUTH,
+export type DMSHemisphereIndicator = 0 | 1 | 2 | 3;
+export type DMSTrailingComponent = 0 | 1 | 2;
 
-  DEGREE: DMSTrailingComponent.DEGREE,
-  MINUTE: DMSTrailingComponent.MINUTE,
-  SECOND: DMSTrailingComponent.SECOND,
-
-  Decode: (dms: string) => {
-    val: number;
-    ind: DMSHemisphereIndicator;
-  },
-
-  DecodeLatLon: (
-    stra: string,
-    strb: string,
-    longfirst?: boolean // default = false
-  ) => {
-    lat: number;
-    lon: number;
-  },
-
-  DecodeAngle: (angstr: string) => number,
-
-  DecodeAzimuth: (azistr: string) => number,
-
-  Encode: (
-    angle: number,
-    trailing: DMSTrailingComponent,
-    prec: number,
-    ind?: DMSHemisphereIndicator // default = NONE
-  ) => string
+export declare const Decode: (dms: string) => {
+  val: number;
+  ind: DMSHemisphereIndicator;
 };
+
+export declare const DecodeLatLon: (
+  stra: string,
+  strb: string,
+  longfirst?: boolean // default = false
+) => {
+  lat: number;
+  lon: number;
+};
+
+export declare const DecodeAngle: (angstr: string) => number;
+
+export declare const DecodeAzimuth: (azistr: string) => number;
+
+export declare const Encode: (
+  angle: number,
+  trailing: DMSTrailingComponent,
+  prec: number,
+  ind?: DMSHemisphereIndicator // default = NONE
+) => string;


### PR DESCRIPTION
hi!

Thanks so much for `geographiclib` and this Javascript port! Unfortunately, the Typescript types in `geographiclib-dms` are wrong. The published version of the types declares a constant called `DMS` with all functions of the library as members of that object, but the library itself exports its functions as root-level exports.

So, this PR adjusts the declared types to match the shape presently exported by the library. It also removes the `enum`s in favor of constant integers, as the library does not export actual `enum` in the form expected by Typescript.

This is in some sense a breaking change for Typescript users of `geographiclib-dms`, but, as there is not presently any way to use `geographiclib-dms` in a Typescript project in a way that both passes typechecking and works properly at runtime, there should not be many users whose work is broken by the change.